### PR TITLE
set socket to non-blocking for connect

### DIFF
--- a/src/posix/os-socket.h
+++ b/src/posix/os-socket.h
@@ -286,7 +286,9 @@ namespace PLATFORM
   inline bool TcpConnectSocket(tcp_socket_t socket, struct addrinfo* addr, int *iError, uint64_t iTimeout = 0)
   {
     *iError = 0;
+    SocketSetBlocking(socket, false);
     int iConnectResult = connect(socket, addr->ai_addr, addr->ai_addrlen);
+    SocketSetBlocking(socket, true);
     if (iConnectResult == -1)
     {
       if (errno == EINPROGRESS)


### PR DESCRIPTION
I noticed this on OSX. Without a running backend the thread never returned from connect.