### PR TITLE
fixed: libdir in UseMultiArch.cmake default to lib

### DIFF
--- a/UseMultiArch.cmake
+++ b/UseMultiArch.cmake
@@ -20,7 +20,9 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" AND
   if (EXISTS "/etc/debian_version")
 	set (_libdir_def "lib/${CMAKE_LIBRARY_ARCHITECTURE}")
 	set (_libdir_noarch "lib")
-  else (EXISTS "/etc/debian_version")
+  elseif (EXISTS "/etc/fedora-release" OR
+          EXISTS "/etc/redhat-release" OR
+          EXISTS "/etc/slackware-version")
 	# 64-bit system?
 	if (CMAKE_SIZEOF_VOID_P EQUAL 8)
 	  set (_libdir_noarch "lib64")
@@ -28,10 +30,10 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" AND
 	  set (_libdir_noarch "lib")
 	endif (CMAKE_SIZEOF_VOID_P EQUAL 8)
 	set (_libdir_def "${_libdir_noarch}")
-  endif (EXISTS "/etc/debian_version")
-else ()
-  set (_libdir_def "lib")
-  set (_libdir_noarch "lib")
+  else ()
+    set (_libdir_def "lib")
+    set (_libdir_noarch "lib")
+  endif ()
 endif ()
 
 # let the user override if somewhere else is desirable


### PR DESCRIPTION
platform v1.0.10, kodi 15.0rc1 on Arch Linux

On Arch Linux I'm forced to manually set CMAKE_INSTALL_LIBDIR and CMAKE_INSTALL_LIBDIR_NOARCH to "lib".

The attached commit fix this issue.

[It looks like it's also happening with OpenELEC.](https://github.com/OpenELEC/OpenELEC.tv/blob/master/packages/mediacenter/platform/package.mk#L39)