### PR TITLE
fix libdir for gentoo

### DIFF
--- a/UseMultiArch.cmake
+++ b/UseMultiArch.cmake
@@ -22,7 +22,8 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" AND
 	set (_libdir_noarch "lib")
   elseif (EXISTS "/etc/fedora-release" OR
           EXISTS "/etc/redhat-release" OR
-          EXISTS "/etc/slackware-version")
+          EXISTS "/etc/slackware-version" OR
+          EXISTS "/etc/gentoo-release")
 	# 64-bit system?
 	if (CMAKE_SIZEOF_VOID_P EQUAL 8)
 	  set (_libdir_noarch "lib64")


### PR DESCRIPTION
This adds proper lib64 handling for gentoo and syncs it with the changes done in kodi-platform.