### PR TITLE
Avoid that cmake removes variables from pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ install(FILES src/util/atomic.h
         DESTINATION include/p8-platform/util)
 
 IF(NOT WIN32)
-  configure_file(p8-platform.pc.in p8-platform.pc)
+  configure_file(p8-platform.pc.in p8-platform.pc @ONLY)
   install(FILES ${CMAKE_BINARY_DIR}/p8-platform.pc
           DESTINATION ${CMAKE_INSTALL_LIBDIR_NOARCH}/pkgconfig)
 ENDIF(NOT WIN32)


### PR DESCRIPTION
Currently cmake will remove the variables from the p8-platform.pc when running `configure_file`, leading to a `-I` argument without a value in Cflags.