### PR TITLE
[tvos] - remove iokit linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(p8-platform_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
 
 if(NOT ${CORE_SYSTEM_NAME} STREQUAL "")
   if(${CORE_SYSTEM_NAME} STREQUAL "osx" OR ${CORE_SYSTEM_NAME} STREQUAL "ios")
-    list(APPEND p8-platform_LIBRARIES "-framework CoreVideo -framework IOKit")
+    list(APPEND p8-platform_LIBRARIES "-framework CoreVideo")
   endif()
 endif()
 


### PR DESCRIPTION
Same like for kodi-platform *c&p*:

I know linking against IOKit framework was added for a reason. But i can't find any addon in our repo that needs this atm. Also on TVOS IOKit is a private framework which we can't link to.

I already did a binary-addons testbuild on jenkins with this and didn't see any issues.