### PR TITLE
Fixing #30 => https instead of git/ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "support"]
 	path = support
-	url = git@github.com:Pulse-Eight/libcec-support.git
+	url = https://github.com/Pulse-Eight/libcec-support.git


### PR DESCRIPTION
reference submodule via https instead of git/ssh to allow public clone (without ssh key registered to github).