### PR TITLE
StringUtils: fix build with -std=c++17

### DIFF
--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -453,7 +453,7 @@ static int isspace_c(char c)
 
 std::string& StringUtils::TrimLeft(std::string &str)
 {
-  str.erase(str.begin(), ::find_if(str.begin(), str.end(), ::not1(::ptr_fun(isspace_c))));
+  str.erase(str.begin(), ::find_if(str.begin(), str.end(), [](char s) { return isspace_c(s) == 0; }));
   return str;
 }
 
@@ -466,7 +466,7 @@ std::string& StringUtils::TrimLeft(std::string &str, const char* const chars)
 
 std::string& StringUtils::TrimRight(std::string &str)
 {
-  str.erase(::find_if(str.rbegin(), str.rend(), ::not1(::ptr_fun(isspace_c))).base(), str.end());
+  str.erase(::find_if(str.rbegin(), str.rend(), [](char s) { return isspace_c(s) == 0; }).base(), str.end());
   return str;
 }
 


### PR DESCRIPTION
Fixes build error with c++17 standard. I'm not 100% if this is correct though.

```
/home/jenkins/workspace/Android-ARM64/tools/depends/target/p8-platform/aarch64-linux-android-21-debug/src/util/StringUtils.cpp:456:69: error: no member named 'ptr_fun' in the global namespace
  str.erase(str.begin(), ::find_if(str.begin(), str.end(), ::not1(::ptr_fun(isspace_c))));
                                                                  ~~^
/home/jenkins/workspace/Android-ARM64/tools/depends/target/p8-platform/aarch64-linux-android-21-debug/src/util/StringUtils.cpp:469:58: error: no member named 'ptr_fun' in the global namespace
  str.erase(::find_if(str.rbegin(), str.rend(), ::not1(::ptr_fun(isspace_c))).base(), str.end());
                                                       ~~^
```

~~std::ptr_fun was removed in c++17 https://en.cppreference.com/w/cpp/utility/functional/ptr_fun
std::not_fn was added in c++17 https://en.cppreference.com/w/cpp/utility/functional/not_fn~~

EDIT: use lambdas instead