### PR TITLE
[cmake] require c++11 as the minimum standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ project(p8-platform)
 cmake_minimum_required(VERSION 2.8.9)
 enable_language(CXX)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_EXTENSIONS NO)
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 find_package(Threads REQUIRED)


### PR DESCRIPTION
Introduced in #45 lambdas require a minimum of c++11 standard in order to build. This is needed because clang seems to default to c++98 by default. see, https://clang.llvm.org/cxx_status.html

```
cmake -DCMAKE_CXX_STANDARD=98 ..
make
```
results in failure
```
/home/lukas/Documents/git/platform/src/util/StringUtils.cpp: In static member function ‘static std::string& StringUtils::TrimLeft(std::string&)’:
/home/lukas/Documents/git/platform/src/util/StringUtils.cpp:456:99: warning: lambda expressions only available with ‘-std=c++11’ or ‘-std=gnu++11’
  456 |   str.erase(str.begin(), ::find_if(str.begin(), str.end(), [](char s) { return isspace_c(s) == 0; }));
      |                                                                                                   ^
```

This PR fixes this issue