### PR TITLE
Fix building as a git submodule (or as any subfolder)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,13 +103,13 @@ endif(MSVC)
 
 if(NOT WIN32)
   configure_file(p8-platform.pc.in p8-platform.pc @ONLY)
-  install(FILES ${CMAKE_BINARY_DIR}/p8-platform.pc
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/p8-platform.pc
           DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif(NOT WIN32)
 
 # config mode
 configure_file (p8-platform-config.cmake.in
                 p8-platform-config.cmake @ONLY)
-install(FILES ${CMAKE_BINARY_DIR}/p8-platform-config.cmake
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/p8-platform-config.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/p8-platform)
 


### PR DESCRIPTION
## Description

CMakeLists.txt uses the variable `CMAKE_BINARY_DIR` to search for configured files. However, when this repo is being built as a submodule (or as any other form that places it in a subdirectory below the root CMakeLists.txt), configured files can't be found in the root build folder because they're placed in corresponding subdirectories.

Fix this by using `CMAKE_CURRENT_BINARY_DIR`, which handles building this library from a subdirectory correctly.

## How has this been tested?

I cloned this repo to the subfolder `lib/p8-platform`, and then in CMakeLists.txt I added the line `add_subdirectory(lib/p8-platform)`.

Before patch, error was:

```
  --- stderr:
  CMake Error: can't find 'p8-platform.pc'
```

After patch, no error and the build succeeds.