### PR TITLE
Add support for building for Windows ARM64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,9 @@ if(WIN32)
 
   endif(MSVC)
 
-  if (NOT ${WIN64} AND NOT ${_M_ARM64})
+  if ((NOT ${WIN64}) AND (NOT ${_M_ARM64}))
     add_definitions(-D_USE_32BIT_TIME_T)
-  endif(NOT ${WIN64} AND NOT ${_M_ARM64})
+  endif((NOT ${WIN64}) AND (NOT ${_M_ARM64}))
 endif(WIN32)
 
 install(TARGETS p8-platform DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,9 @@ if(WIN32)
 
   endif(MSVC)
 
-  if (NOT ${WIN64})
+  if (NOT ${WIN64} AND NOT ${_M_ARM64})
     add_definitions(-D_USE_32BIT_TIME_T)
-  endif(NOT ${WIN64})
+  endif(NOT ${WIN64} AND NOT ${_M_ARM64})
 endif(WIN32)
 
 install(TARGETS p8-platform DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/os.h
+++ b/src/os.h
@@ -31,7 +31,7 @@
  *     http://www.pulse-eight.net/
  */
 
-#if (defined(_WIN32) || defined(_WIN64))
+#if (defined(_WIN32) || defined(_WIN64) || defined(_M_ARM64))
 #include "windows/os-types.h"
 #else
 #include "posix/os-types.h"

--- a/src/util/StdString.h
+++ b/src/util/StdString.h
@@ -363,7 +363,7 @@
 
 #if !defined (SS_ANSI) && defined(_MSC_VER)
   #undef SS_IS_INTRESOURCE
-  #if defined(_WIN64)
+  #if defined(_WIN64) || defined(_M_ARM64)
     #define SS_IS_INTRESOURCE(_r) (((unsigned __int64)(_r) >> 16) == 0)
   #else
     #define SS_IS_INTRESOURCE(_r) (((unsigned long)(_r) >> 16) == 0)

--- a/src/windows/inttypes.h
+++ b/src/windows/inttypes.h
@@ -186,13 +186,13 @@ typedef struct {
 #define SCNdMAX     "I64d"
 #define SCNiMAX     "I64i"
 
-#ifdef _WIN64 // [
+#if defined(_WIN64) || defined(_M_ARM64) // [
 #  define SCNdPTR     "I64d"
 #  define SCNiPTR     "I64i"
-#else  // _WIN64 ][
+#else  // _WIN64 || _M_ARM64 ][
 #  define SCNdPTR     "ld"
 #  define SCNiPTR     "li"
-#endif  // _WIN64 ]
+#endif  // _WIN64 || _M_ARM64]
 
 // The fscanf macros for unsigned integers are:
 #define SCNo8       "o"
@@ -252,17 +252,17 @@ typedef struct {
 #define SCNxMAX     "I64x"
 #define SCNXMAX     "I64X"
 
-#ifdef _WIN64 // [
+#defined(_WIN64) || defined(_M_ARM64) // [
 #  define SCNoPTR     "I64o"
 #  define SCNuPTR     "I64u"
 #  define SCNxPTR     "I64x"
 #  define SCNXPTR     "I64X"
-#else  // _WIN64 ][
+#else  // _WIN64 || _M_ARM64 ][
 #  define SCNoPTR     "lo"
 #  define SCNuPTR     "lu"
 #  define SCNxPTR     "lx"
 #  define SCNXPTR     "lX"
-#endif  // _WIN64 ]
+#endif  // _WIN64 || _M_ARM64 ]
 
 #endif // __STDC_FORMAT_MACROS ]
 

--- a/src/windows/os-types.h
+++ b/src/windows/os-types.h
@@ -76,7 +76,7 @@ typedef HANDLE serial_socket_t;
 #define INVALID_SERIAL_SOCKET_VALUE INVALID_HANDLE_VALUE
 
 #ifndef _SSIZE_T_DEFINED
-#ifdef  _WIN64
+#if defined(_WIN64) || defined(_M_ARM64)
 typedef __int64    ssize_t;
 #else
 typedef _W64 int   ssize_t;

--- a/src/windows/stdint.h
+++ b/src/windows/stdint.h
@@ -111,13 +111,13 @@ typedef uint32_t  uint_fast32_t;
 typedef uint64_t  uint_fast64_t;
 
 // 7.18.1.4 Integer types capable of holding object pointers
-#ifdef _WIN64 // [
+#if defined(_WIN64) || defined(_M_ARM64) // [
    typedef signed __int64    intptr_t;
    typedef unsigned __int64  uintptr_t;
-#else // _WIN64 ][
+#else // _WIN64 || _M_ARM64 ][
    typedef _W64 signed int   intptr_t;
    typedef _W64 unsigned int uintptr_t;
-#endif // _WIN64 ]
+#endif // _WIN64 || _M_ARM64 ]
 
 // 7.18.1.5 Greatest-width integer types
 typedef int64_t   intmax_t;
@@ -171,15 +171,15 @@ typedef uint64_t  uintmax_t;
 #define UINT_FAST64_MAX  UINT64_MAX
 
 // 7.18.2.4 Limits of integer types capable of holding object pointers
-#ifdef _WIN64 // [
+#if defined(_WIN64) || defined(_M_ARM64)// [
 #  define INTPTR_MIN   INT64_MIN
 #  define INTPTR_MAX   INT64_MAX
 #  define UINTPTR_MAX  UINT64_MAX
-#else // _WIN64 ][
+#else // _WIN64 || _M_ARM64 ][
 #  define INTPTR_MIN   INT32_MIN
 #  define INTPTR_MAX   INT32_MAX
 #  define UINTPTR_MAX  UINT32_MAX
-#endif // _WIN64 ]
+#endif // _WIN64 || _M_ARM64 ]
 
 // 7.18.2.5 Limits of greatest-width integer types
 #define INTMAX_MIN   INT64_MIN
@@ -188,23 +188,23 @@ typedef uint64_t  uintmax_t;
 
 // 7.18.3 Limits of other integer types
 
-#ifdef _WIN64 // [
+#if defined(_WIN64) || defined(_M_ARM64)// [
 #  define PTRDIFF_MIN  _I64_MIN
 #  define PTRDIFF_MAX  _I64_MAX
-#else  // _WIN64 ][
+#else  // _WIN64 || _M_ARM64 ][
 #  define PTRDIFF_MIN  _I32_MIN
 #  define PTRDIFF_MAX  _I32_MAX
-#endif  // _WIN64 ]
+#endif  // _WIN64 || _M_ARM64 ]
 
 #define SIG_ATOMIC_MIN  INT_MIN
 #define SIG_ATOMIC_MAX  INT_MAX
 
 #ifndef SIZE_MAX // [
-#  ifdef _WIN64 // [
+#  if defined(_WIN64) || defined(_M_ARM64)// [
 #     define SIZE_MAX  _UI64_MAX
-#  else // _WIN64 ][
+#  else // _WIN64 || _M_ARM64 ][
 #     define SIZE_MAX  _UI32_MAX
-#  endif // _WIN64 ]
+#  endif // _WIN64 || _M_ARM64 ]
 #endif // SIZE_MAX ]
 
 // WCHAR_MIN and WCHAR_MAX are also defined in <wchar.h>

--- a/windows/build-lib.cmd
+++ b/windows/build-lib.cmd
@@ -37,7 +37,7 @@ GOTO exit
 ECHO.%~dp0 requires 4 parameters
 ECHO.  %~dp0 [architecture] [type] [version] [install path]
 ECHO.
-ECHO. architecture:    amd64 x86
+ECHO. architecture:    amd64 x86 arm64
 ECHO. type:            Release Debug
 ECHO. version:         Visual Studio version (2019)
 ECHO. install path:    installation path without quotes

--- a/windows/build.cmd
+++ b/windows/build.cmd
@@ -13,7 +13,7 @@ IF EXIST "%MYDIR%..\build" (
   RMDIR /s /q "%MYDIR%..\build"
 )
 
-FOR %%T IN (amd64 x86) DO (
+FOR %%T IN (amd64 x86 arm64) DO (
   CALL "%MYDIR%\build-lib.cmd" %%T %BUILDTYPE% %VSVERSION% "%INSTALLPATH%"
 )
 


### PR DESCRIPTION
This PR adds changes for "support" submodule to support building libcec for Windows ARM64.
This is one of my 3 PRs which enable libcec to be built for Windows ARM64.
There's also one for "support" submodule as well as the main "libcec" repository.

https://github.com/Pulse-Eight/libcec-support/pull/4
https://github.com/Pulse-Eight/libcec/pull/670